### PR TITLE
use date_recorded for year when version is ID3v2.4

### DIFF
--- a/src/models/track.rs
+++ b/src/models/track.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use id3::TagLike;
+use id3::{TagLike, Timestamp};
 use image::ImageReader;
 use std::io::Cursor;
 
@@ -164,11 +164,19 @@ impl Track {
                 wrote += 1;
             }
             if let Some(year) = &self.year {
-                tag.set_year(*year);
-                println!(
-                    "Set year successfully: {:?}",
-                    tag.year().expect("{Error getting set year}")
-                );
+                if self.version == id3::Version::Id3v24 {
+                    tag.set_date_recorded(Timestamp { year: *year, month: None, day: None, hour: None, minute: None, second: None });
+                    println!(
+                        "Set year successfully: {:?}",
+                        tag.date_recorded().expect("{Error getting set year}").year
+                    );
+                } else {
+                    tag.set_year(*year);
+                    println!(
+                        "Set year successfully: {:?}",
+                        tag.year().expect("{Error getting set year}")
+                    );
+                }
                 wrote += 1;
             }
 
@@ -206,7 +214,7 @@ impl Track {
                     Err(e) => println!("Error saving tag to file :: {}", e),
                 }
             } else {
-                println!("Missing arguements, use 'editag --help' for help ");
+                println!("Missing arguments, use 'editag --help' for help ");
             }
         } else {
             println!("Invalid file, use 'editag --help' for help  ");


### PR DESCRIPTION
Hi @blackout358 - thanks for your work on editag, it's a great little app!

I noticed an issue with years when the version is ID3v2.4, so I made a small change, hope this PR is ok?

Basically, the year wasn't showing up for me in my music player of choice (Poweramp on Android). If you [see here](https://id3.org/id3v2.4.0-changes), TYER (year) was replaced by TDRC (recording time) for v2.4, so when `--year` is used the year is now set using `set_date_recorded()` instead of `set_year()`.